### PR TITLE
Change simulation api to support a stateless solution

### DIFF
--- a/objects.proto
+++ b/objects.proto
@@ -6,6 +6,8 @@ option java_multiple_files = false;
 option java_package = "EcdarProtoBuf";
 option java_outer_classname = "ObjectProtos";
 
+import "component.proto";
+
 message StateTuple {
   message LocationTuple {
     string name = 1;
@@ -73,4 +75,9 @@ message Edge {
 message Decision {
   State source = 1;
   Edge edge = 2;
+}
+
+message SimulationState {
+  Component component = 1;
+  repeated DecisionPoint decision_points = 2;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -26,26 +26,28 @@ message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;
 }
+message ComponentClock {
+  SpecificComponent specific_component = 1;
+  string clock_name = 2;
+}
+
+message Constraint {
+  // This message represents if (!strict) { x - y <= c } else { x - y < c }
+  ComponentClock x = 1;
+  ComponentClock y = 2;
+  bool strict = 3;
+  int32 c = 4;
+}
+
+message Conjunction {
+  repeated Constraint constraints = 1;
+}
+
+message Disjunction {
+  repeated Conjunction conjunctions = 1;
+}
 
 message Zone {
-  message Disjunction {
-    message Conjunction {
-      message Constraint {
-        message ComponentClock {
-          SpecificComponent specific_component = 1;
-          string clock_name = 2;
-        }
-        // This message represents if (!strict) { x - y <= c } else { x - y < c }
-        ComponentClock x = 1;
-        ComponentClock y = 2;
-        bool strict = 3;
-        int32 c = 4;
-      }
-      repeated Constraint constraints = 1;
-    }
-
-    repeated Conjunction conjunctions = 1;
-  }
   Disjunction disjunction = 1;
 }
 
@@ -58,7 +60,7 @@ message LocationTuple {
 }
 
 message State {
-  LocationTuple location_tuple = 1;
+  string location_id = 1;
   Zone zone = 2;
 }
 

--- a/query.proto
+++ b/query.proto
@@ -74,20 +74,11 @@ message SimulationStartRequest {
   ComponentsInfo components_info = 2;
 }
 
-message SimulationStartResponse {
-  int32 simulation_id = 1;
-  DecisionPoint initial_decision_point = 2;
-}
-
 message SimulationStepRequest {
-  int32 simulation_id = 1;
-  Decision decision = 2;
+  SimulationState current_state = 1;
+  Decision chosen_decision = 2;
 }
 
 message SimulationStepResponse {
-  repeated DecisionPoint new_possible_decision_points = 1;
-}
-
-message SimulationStopRequest {
-  int32 simulation_id = 1;
+  SimulationState new_state = 1;
 }

--- a/services.proto
+++ b/services.proto
@@ -16,7 +16,6 @@ service EcdarBackend {
     rpc GetUserToken(google.protobuf.Empty) returns (UserTokenResponse);
     rpc SendQuery(QueryRequest) returns (QueryResponse);
 
-    rpc StartSimulation(SimulationStartRequest) returns (SimulationStartResponse);
+    rpc StartSimulation(SimulationStartRequest) returns (SimulationStepResponse);
     rpc TakeSimulationStep(SimulationStepRequest) returns (SimulationStepResponse);
-    rpc StopSimulation(SimulationStopRequest) returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
We have internally discussed in the group a stateless solution for the simulation api. Overall we think it’s a better solution see reasoning below. Note that these changes only affect the gui group.

**Stateful:**
(+) less traffic between server and gui
(-) Stateful, it adds quite a bit of complexity to both the server and the gui
(-) Hard to test :(

**Functional:**
(+) easy to test, acts as a function that takes a state and a choice as input and produces a new state as output
(+) simpler api
(+) easy to multithread, no shared state!
(-) quite a bit more traffic
