### PR TITLE
Improve gRPC committee changes

### DIFF
--- a/component.proto
+++ b/component.proto
@@ -13,6 +13,11 @@ message Component {
   }
 }
 
+message ComponentsInfo {
+  repeated Component components = 1;
+  uint32 components_hash = 2;
+}
+
 /*
 message Location {
     string id = 1;

--- a/objects.proto
+++ b/objects.proto
@@ -66,9 +66,3 @@ message Decision {
   State source = 1;
   Edge edge = 2;
 }
-
-message SimulationState {
-  string component_composition = 1;
-  ComponentsInfo components_info = 2;
-  repeated DecisionPoint decision_points = 3;
-}

--- a/objects.proto
+++ b/objects.proto
@@ -60,7 +60,7 @@ message LocationTuple {
 }
 
 message State {
-  LocationTuple location_id = 1;
+  LocationTuple location_tuple = 1;
   Zone zone = 2;
 }
 
@@ -81,6 +81,6 @@ message Decision {
 
 message SimulationState {
   string component_composition = 1;
-  ComponentsInfo components = 2;
+  ComponentsInfo components_info = 2;
   repeated DecisionPoint decision_points = 3;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -60,7 +60,7 @@ message LocationTuple {
 }
 
 message State {
-  string location_id = 1;
+  LocationTuple location_id = 1;
   Zone zone = 2;
 }
 
@@ -80,6 +80,7 @@ message Decision {
 }
 
 message SimulationState {
-  Component component = 1;
-  repeated DecisionPoint decision_points = 2;
+  string component_composition = 1;
+  ComponentsInfo components = 2;
+  repeated DecisionPoint decision_points = 3;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -17,11 +17,6 @@ message StateTuple {
   repeated Zone federation = 2;
 }
 
-message Transition {
-  // Figure out what we need here
-  // repeated Edge edges = 1; //?
-}
-
 message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;

--- a/objects.proto
+++ b/objects.proto
@@ -8,15 +8,6 @@ option java_outer_classname = "ObjectProtos";
 
 import "component.proto";
 
-message StateTuple {
-  message LocationTuple {
-    string name = 1;
-    // Maybe the component name? or some comp id?
-  }
-  LocationTuple location = 1;
-  repeated Zone federation = 2;
-}
-
 message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;
@@ -42,7 +33,7 @@ message Disjunction {
   repeated Conjunction conjunctions = 1;
 }
 
-message Zone {
+message Federation {
   Disjunction disjunction = 1;
 }
 
@@ -57,7 +48,7 @@ message LocationTuple {
 
 message State {
   LocationTuple location_tuple = 1;
-  Zone zone = 2;
+  Federation federation = 2;
 }
 
 message DecisionPoint {

--- a/objects.proto
+++ b/objects.proto
@@ -51,11 +51,12 @@ message Zone {
   Disjunction disjunction = 1;
 }
 
+message Location {
+  string id = 1;
+  SpecificComponent specific_component = 2;
+}
+
 message LocationTuple {
-  message Location {
-    string id = 1;
-    string component_name = 2;
-  }
   repeated Location locations = 1;
 }
 

--- a/objects.proto
+++ b/objects.proto
@@ -12,6 +12,7 @@ message SpecificComponent {
   string component_name = 1;
   uint32 component_index = 2;
 }
+
 message ComponentClock {
   SpecificComponent specific_component = 1;
   string clock_name = 2;

--- a/query.proto
+++ b/query.proto
@@ -38,22 +38,22 @@ message QueryResponse {
 
     message RefinementResult {
       bool success = 1;
-      repeated StateTuple relation = 2;
-      StateTuple state = 3;
+      repeated State relation = 2;
+      State state = 3;
     }
 
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
-      StateTuple state = 2;
+      State state = 2;
     }
     message DeterminismResult {
       bool success = 1;
-      StateTuple state = 2;
+      State state = 2;
     }
     message ImplementationResult {
       bool success = 1;
-      StateTuple state = 2;
+      State state = 2;
     }
     message ReachabilityResult {
       bool success = 1;

--- a/query.proto
+++ b/query.proto
@@ -58,7 +58,7 @@ message QueryResponse {
     message ReachabilityResult {
       bool success = 1;
       string reason = 2;
-      StateTuple state = 3;
+      State state = 3;
     }
 
     oneof result {

--- a/query.proto
+++ b/query.proto
@@ -14,10 +14,6 @@ message IgnoredInputOutputs {
   repeated string ignored_outputs = 2;
 }
 
-message ComponentsInfo {
-  repeated Component components = 1;
-  uint32 components_hash = 2;
-}
 
 message UserTokenResponse {
   int32 user_id = 1;

--- a/query.proto
+++ b/query.proto
@@ -90,3 +90,22 @@ message SimulationStepRequest {
 message SimulationStepResponse {
   SimulationState new_state = 1;
 }
+
+// --- ALTERNATIVE SIMULATION API ---
+// message SimulationStartRequest {
+//   SimulationInfo simulation_info = 1;
+// }
+
+// message SimulationStepRequest {
+//   SimulationInfo simulation_info = 1;
+//   Decision chosen_decision = 2;
+// }
+
+// message SimulationStepResponse {
+//   DecisionPoint new_decision_point = 1;
+// }
+
+// message SimulationInfo {
+//   string component_composition = 2; // example: A || B || A
+//   ComponentsInfo components_info = 3;
+// }

--- a/query.proto
+++ b/query.proto
@@ -77,35 +77,35 @@ message UserTokenError {
   string error_message = 2;
 }
 
-message SimulationStartRequest {
-  string component_composition = 1; // example: A || B || A
-  ComponentsInfo components_info = 2;
-}
-
-message SimulationStepRequest {
-  SimulationState current_state = 1;
-  Decision chosen_decision = 2;
-}
-
-message SimulationStepResponse {
-  SimulationState new_state = 1;
-}
-
-// --- ALTERNATIVE SIMULATION API ---
 // message SimulationStartRequest {
-//   SimulationInfo simulation_info = 1;
+//   string component_composition = 1; // example: A || B || A
+//   ComponentsInfo components_info = 2;
 // }
 
 // message SimulationStepRequest {
-//   SimulationInfo simulation_info = 1;
+//   SimulationState current_state = 1;
 //   Decision chosen_decision = 2;
 // }
 
 // message SimulationStepResponse {
-//   DecisionPoint new_decision_point = 1;
+//   SimulationState new_state = 1;
 // }
 
-// message SimulationInfo {
-//   string component_composition = 2; // example: A || B || A
-//   ComponentsInfo components_info = 3;
-// }
+// --- ALTERNATIVE SIMULATION API ---
+message SimulationStartRequest {
+  SimulationInfo simulation_info = 1;
+}
+
+message SimulationStepRequest {
+  SimulationInfo simulation_info = 1;
+  Decision chosen_decision = 2;
+}
+
+message SimulationStepResponse {
+  DecisionPoint new_decision_point = 1;
+}
+
+message SimulationInfo {
+  string component_composition = 2; // example: A || B || A
+  ComponentsInfo components_info = 3;
+}

--- a/query.proto
+++ b/query.proto
@@ -82,21 +82,6 @@ message UserTokenError {
   string error_message = 2;
 }
 
-// message SimulationStartRequest {
-//   string component_composition = 1; // example: A || B || A
-//   ComponentsInfo components_info = 2;
-// }
-
-// message SimulationStepRequest {
-//   SimulationState current_state = 1;
-//   Decision chosen_decision = 2;
-// }
-
-// message SimulationStepResponse {
-//   SimulationState new_state = 1;
-// }
-
-// --- ALTERNATIVE SIMULATION API ---
 message SimulationStartRequest {
   SimulationInfo simulation_info = 1;
 }

--- a/query.proto
+++ b/query.proto
@@ -39,20 +39,24 @@ message QueryResponse {
     message RefinementResult {
       bool success = 1;
       repeated State relation = 2;
+      string reason = 2;
       State state = 3;
     }
 
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
+      string reason = 2;
       State state = 2;
     }
     message DeterminismResult {
       bool success = 1;
+      string reason = 2;
       State state = 2;
     }
     message ImplementationResult {
       bool success = 1;
+      string reason = 2;
       State state = 2;
     }
     message ReachabilityResult {

--- a/query.proto
+++ b/query.proto
@@ -39,25 +39,25 @@ message QueryResponse {
     message RefinementResult {
       bool success = 1;
       repeated State relation = 2;
-      string reason = 2;
-      State state = 3;
+      string reason = 3;
+      State state = 4;
     }
 
     message ComponentResult { Component component = 1; }
     message ConsistencyResult {
       bool success = 1;
       string reason = 2;
-      State state = 2;
+      State state = 3;
     }
     message DeterminismResult {
       bool success = 1;
       string reason = 2;
-      State state = 2;
+      State state = 3;
     }
     message ImplementationResult {
       bool success = 1;
       string reason = 2;
-      State state = 2;
+      State state = 3;
     }
     message ReachabilityResult {
       bool success = 1;

--- a/services.proto
+++ b/services.proto
@@ -6,8 +6,6 @@ option java_multiple_files = false;
 option java_package = "EcdarProtoBuf";
 option java_outer_classname = "ServiceProtos";
 
-import "component.proto";
-import "objects.proto";
 import "query.proto";
 
 import "google/protobuf/empty.proto";


### PR DESCRIPTION
For simulation requests, we have changed the protocol to send components and their composition instead of a potentially huge component.

# Main changes
- Change location id to location tuple in State message
- Send ComponentsInfo and composition instead of just a component in simulation requests
- A proposal for an alternative Simulation API.

# Minor changes
- Move ComponentsInfo message to component.proto
- Remove unused imports in services.proto
- Replace StateTuple message with State message
- Remove Transition message, it was unused
- Rename Zone Message, Federation. 
