### PR TITLE
group 17 reachability gRPC changes

### DIFF
--- a/objects.proto
+++ b/objects.proto
@@ -68,6 +68,5 @@ message Decision {
 }
 
 message Path {
-  SpecificComponent specific_component = 1;
-  repeated string edge_ids = 2;
+  repeated string edge_ids = 1;
 }

--- a/objects.proto
+++ b/objects.proto
@@ -66,3 +66,8 @@ message Decision {
   State source = 1;
   Edge edge = 2;
 }
+
+message Path {
+  SpecificComponent specific_component = 1;
+  repeated string edge_ids = 2;
+}

--- a/query.proto
+++ b/query.proto
@@ -63,7 +63,7 @@ message QueryResponse {
       bool success = 1;
       string reason = 2;
       State state = 3;
-      repeated Edge edges = 4;
+      repeated Path component_paths = 4;
     }
 
     oneof result {


### PR DESCRIPTION
This pull request makes some changes to the reachability result.

Instead of result a list of edges as a path for each component combined, we have made a new message called `Path` that represents the path from a start state to an end state for the individual component.

Therefore in the message `ReachabilityResult`, we result a list of paths - one path for each individual component.