### PR TITLE
Remove UserTokenError

### DIFF
--- a/query.proto
+++ b/query.proto
@@ -36,68 +36,56 @@ message QueryRequest {
   Settings settings = 6;
 }
 
-message QueryResponse { 
-  oneof response {
-    QueryOk query_ok = 1;
-    UserTokenError user_token_error = 2;  
+message QueryResponse {
+  int32 query_id = 1;
+
+  message RefinementResult {
+    bool success = 1;
+    repeated State relation = 2;
+    string reason = 3;
+    State state = 4;
+    string action = 5;
   }
 
-  message QueryOk {
-    int32 query_id = 1;
-
-    message RefinementResult {
-      bool success = 1;
-      repeated State relation = 2;
-      string reason = 3;
-      State state = 4;
-      string action = 5;
-    }
-
-    message ComponentResult { Component component = 1; }
-    message ConsistencyResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-      string action = 4;
-    }
-    message DeterminismResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-      string action = 4;
-    }
-    message ImplementationResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-    }
-    message ReachabilityResult {
-      bool success = 1;
-      string reason = 2;
-      State state = 3;
-      repeated Path component_paths = 4;
-    }
-
-    oneof result {
-      RefinementResult refinement = 3;
-      ComponentResult component = 4;
-      ConsistencyResult consistency = 5;
-      DeterminismResult determinism = 6;
-      string error = 7;
-      ImplementationResult implementation = 8;
-      ReachabilityResult reachability = 9;
-    }
-    message Information {
-      string subject = 1;
-      string message = 2;
-    }
-    repeated Information info = 10;
+  message ComponentResult { Component component = 1; }
+  message ConsistencyResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+    string action = 4;
   }
-}
+  message DeterminismResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+    string action = 4;
+  }
+  message ImplementationResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+  }
+  message ReachabilityResult {
+    bool success = 1;
+    string reason = 2;
+    State state = 3;
+    repeated Path component_paths = 4;
+  }
 
-message UserTokenError {
-  int32 user_id = 1;
-  string error_message = 2;
+  oneof result {
+    RefinementResult refinement = 3;
+    ComponentResult component = 4;
+    ConsistencyResult consistency = 5;
+    DeterminismResult determinism = 6;
+    string error = 7;
+    ImplementationResult implementation = 8;
+    ReachabilityResult reachability = 9;
+  }
+  message Information {
+    string subject = 1;
+    string message = 2;
+  }
+  repeated Information info = 10;
 }
 
 message SimulationStartRequest {


### PR DESCRIPTION
This was broken because it required Reveaal to store all the user tokens that is has given out. This violates the principle of idempotency. The server cannot know when a user id is no longer in use, because we have no "log out" endpoint and even if we had one the client could crash and thus not send out a "log out" message.

Instead we assume that all clients are well behaved and use GetUserToken to get a token that is not in use.