### PR TITLE
action is now a repeated string, not a string!

### DIFF
--- a/query.proto
+++ b/query.proto
@@ -44,7 +44,7 @@ message QueryResponse {
     repeated State relation = 2;
     string reason = 3;
     State state = 4;
-    string action = 5;
+    repeated string action = 5;
   }
 
   message ComponentResult { Component component = 1; }
@@ -52,13 +52,13 @@ message QueryResponse {
     bool success = 1;
     string reason = 2;
     State state = 3;
-    string action = 4;
+    repeated string action = 4;
   }
   message DeterminismResult {
     bool success = 1;
     string reason = 2;
     State state = 3;
-    string action = 4;
+    repeated string action = 4;
   }
   message ImplementationResult {
     bool success = 1;


### PR DESCRIPTION
Changes to systemRecipe dictates that we allow the transfer of arrays of actions, given that a given component can have more than a single action violating the DisJoint property. 
Changes are limited to actions, these are now a vec! and not a string. 